### PR TITLE
Rewrite wasmer.Instance without lambda calls

### DIFF
--- a/mock/context/instanceBuilderMock.go
+++ b/mock/context/instanceBuilderMock.go
@@ -3,8 +3,8 @@ package mock
 import (
 	"testing"
 
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 	worldmock "github.com/multiversx/mx-chain-vm-v1_4-go/mock/world"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/wasmer"
 )
 

--- a/mock/context/instanceMock.go
+++ b/mock/context/instanceMock.go
@@ -5,15 +5,19 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
+	arwen "github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/wasmer"
 )
+
+type mockMethod func() *InstanceMock
 
 // InstanceMock is a mock for Wasmer instances; it allows creating mock smart
 // contracts within tests, without needing actual WASM smart contracts.
 type InstanceMock struct {
 	Code            []byte
 	Exports         wasmer.ExportsMap
+	DefaultErrors   map[string]error
+	Methods         map[string]mockMethod
 	Points          uint64
 	Data            uintptr
 	GasLimit        uint64
@@ -30,6 +34,8 @@ func NewInstanceMock(code []byte) *InstanceMock {
 	return &InstanceMock{
 		Code:            code,
 		Exports:         make(wasmer.ExportsMap),
+		DefaultErrors:   make(map[string]error),
+		Methods:         make(map[string]mockMethod),
 		Points:          0,
 		Data:            0,
 		GasLimit:        0,
@@ -45,27 +51,32 @@ func (instance *InstanceMock) ID() string {
 }
 
 // AddMockMethod adds the provided function as a mocked method to the instance under the specified name.
-func (instance *InstanceMock) AddMockMethod(name string, method func() *InstanceMock) {
+func (instance *InstanceMock) AddMockMethod(name string, method mockMethod) {
 	instance.AddMockMethodWithError(name, method, nil)
 }
 
 // AddMockMethodWithError adds the provided function as a mocked method to the instance under the specified name and returns an error
-func (instance *InstanceMock) AddMockMethodWithError(name string, method func() *InstanceMock, err error) {
-	wrappedMethod := func(...interface{}) (wasmer.Value, error) {
-		instance := method()
-		if arwen.BreakpointValue(instance.GetBreakpointValue()) != arwen.BreakpointNone {
-			var errMsg string
-			if arwen.BreakpointValue(instance.GetBreakpointValue()) == arwen.BreakpointAsyncCall {
-				errMsg = "breakpoint"
-			} else {
-				errMsg = instance.Host.Output().GetVMOutput().ReturnMessage
-			}
-			err = errors.New(errMsg)
-		}
-		return wasmer.Void(), err
-	}
+func (instance *InstanceMock) AddMockMethodWithError(name string, method mockMethod, err error) {
+	instance.Methods[name] = method
+	instance.DefaultErrors[name] = err
+	instance.Exports[name] = &wasmer.ExportedFunctionCallInfo{}
+}
 
-	instance.Exports[name] = wrappedMethod
+// CallFunction mocked method
+func (instance *InstanceMock) CallFunction(funcName string) (wasmer.Value, error) {
+	err := instance.DefaultErrors[funcName]
+	method := instance.Methods[funcName]
+	newInstance := method()
+	if arwen.BreakpointValue(instance.GetBreakpointValue()) != arwen.BreakpointNone {
+		var errMsg string
+		if arwen.BreakpointValue(instance.GetBreakpointValue()) == arwen.BreakpointAsyncCall {
+			errMsg = "breakpoint"
+		} else {
+			errMsg = newInstance.Host.Output().GetVMOutput().ReturnMessage
+		}
+		err = errors.New(errMsg)
+	}
+	return wasmer.Void(), err
 }
 
 // HasMemory mocked method
@@ -162,6 +173,12 @@ func (instance *InstanceMock) GetMemory() wasmer.MemoryHandler {
 func (instance *InstanceMock) IsFunctionImported(name string) bool {
 	_, ok := instance.Exports[name]
 	return ok
+}
+
+// HasFunction mocked method
+func (instance *InstanceMock) HasFunction(name string) bool {
+	_, has := instance.Methods[name]
+	return has
 }
 
 // GetMockInstance gets the mock instance from the runtime of the provided host

--- a/mock/context/runtimeContextMock.go
+++ b/mock/context/runtimeContextMock.go
@@ -243,6 +243,7 @@ func (r *RuntimeContextMock) GetInstanceExports() wasmer.ExportsMap {
 func (r *RuntimeContextMock) ClearWarmInstanceCache() {
 }
 
+// CallFunction mocked method
 func (r *RuntimeContextMock) CallFunction(_ string) error {
 	return r.Err
 }

--- a/mock/context/runtimeContextMock.go
+++ b/mock/context/runtimeContextMock.go
@@ -2,7 +2,7 @@ package mock
 
 import (
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
+	arwen "github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/wasmer"
 )
 
@@ -15,7 +15,7 @@ type RuntimeContextMock struct {
 	SCAddress              []byte
 	SCCode                 []byte
 	SCCodeSize             uint64
-	CallFunction           string
+	CallFunctionName       string
 	VMType                 []byte
 	ReadOnlyFlag           bool
 	VerifyCode             bool
@@ -149,7 +149,7 @@ func (r *RuntimeContextMock) GetSCCodeSize() uint64 {
 
 // Function mocked method
 func (r *RuntimeContextMock) Function() string {
-	return r.CallFunction
+	return r.CallFunctionName
 }
 
 // Arguments mocked method
@@ -243,17 +243,21 @@ func (r *RuntimeContextMock) GetInstanceExports() wasmer.ExportsMap {
 func (r *RuntimeContextMock) ClearWarmInstanceCache() {
 }
 
+func (r *RuntimeContextMock) CallFunction(_ string) error {
+	return r.Err
+}
+
 // GetFunctionToCall mocked method
-func (r *RuntimeContextMock) GetFunctionToCall() (wasmer.ExportedFunctionCallback, error) {
+func (r *RuntimeContextMock) GetFunctionToCall() (string, error) {
 	if r.Err != nil {
-		return nil, r.Err
+		return "", r.Err
 	}
-	return nil, nil
+	return "", nil
 }
 
 // GetInitFunction mocked method
-func (r *RuntimeContextMock) GetInitFunction() wasmer.ExportedFunctionCallback {
-	return nil
+func (r *RuntimeContextMock) GetInitFunction() string {
+	return ""
 }
 
 // MemLoad mocked method

--- a/mock/context/runtimeContextWrapper.go
+++ b/mock/context/runtimeContextWrapper.go
@@ -2,7 +2,7 @@ package mock
 
 import (
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
+	arwen "github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/wasmer"
 )
 
@@ -84,9 +84,11 @@ type RuntimeContextWrapper struct {
 	// function that will be called by the corresponding RuntimeContext function implementation (by default this will call the same wrapped context function)
 	GetInstanceExportsFunc func() wasmer.ExportsMap
 	// function that will be called by the corresponding RuntimeContext function implementation (by default this will call the same wrapped context function)
-	GetInitFunctionFunc func() wasmer.ExportedFunctionCallback
+	CallFunctionFunc func(funcName string) error
 	// function that will be called by the corresponding RuntimeContext function implementation (by default this will call the same wrapped context function)
-	GetFunctionToCallFunc func() (wasmer.ExportedFunctionCallback, error)
+	GetInitFunctionFunc func() string
+	// function that will be called by the corresponding RuntimeContext function implementation (by default this will call the same wrapped context function)
+	GetFunctionToCallFunc func() (string, error)
 	// function that will be called by the corresponding RuntimeContext function implementation (by default this will call the same wrapped context function)
 	GetPointsUsedFunc func() uint64
 	// function that will be called by the corresponding RuntimeContext function implementation (by default this will call the same wrapped context function)
@@ -280,11 +282,15 @@ func NewRuntimeContextWrapper(inputRuntimeContext *arwen.RuntimeContext) *Runtim
 		return runtimeWrapper.runtimeContext.GetInstanceExports()
 	}
 
-	runtimeWrapper.GetInitFunctionFunc = func() wasmer.ExportedFunctionCallback {
+	runtimeWrapper.CallFunctionFunc = func(funcName string) error {
+		return runtimeWrapper.runtimeContext.CallFunction(funcName)
+	}
+
+	runtimeWrapper.GetInitFunctionFunc = func() string {
 		return runtimeWrapper.runtimeContext.GetInitFunction()
 	}
 
-	runtimeWrapper.GetFunctionToCallFunc = func() (wasmer.ExportedFunctionCallback, error) {
+	runtimeWrapper.GetFunctionToCallFunc = func() (string, error) {
 		return runtimeWrapper.runtimeContext.GetFunctionToCall()
 	}
 
@@ -555,13 +561,18 @@ func (contextWrapper *RuntimeContextWrapper) GetWarmInstance(codeHash []byte) (w
 	return contextWrapper.GetWarmInstanceFunc(codeHash)
 }
 
+// CallFunction calls corresponding xxxFunc function, that by default in turn calls the original method of the wrapped RuntimeContext
+func (contextWrapper *RuntimeContextWrapper) CallFunction(funcName string) error {
+	return contextWrapper.CallFunctionFunc(funcName)
+}
+
 // GetInitFunction calls corresponding xxxFunc function, that by default in turn calls the original method of the wrapped RuntimeContext
-func (contextWrapper *RuntimeContextWrapper) GetInitFunction() wasmer.ExportedFunctionCallback {
+func (contextWrapper *RuntimeContextWrapper) GetInitFunction() string {
 	return contextWrapper.GetInitFunctionFunc()
 }
 
 // GetFunctionToCall calls corresponding xxxFunc function, that by default in turn calls the original method of the wrapped RuntimeContext
-func (contextWrapper *RuntimeContextWrapper) GetFunctionToCall() (wasmer.ExportedFunctionCallback, error) {
+func (contextWrapper *RuntimeContextWrapper) GetFunctionToCall() (string, error) {
 	return contextWrapper.GetFunctionToCallFunc()
 }
 

--- a/vmhost/contexts/instanceTracker.go
+++ b/vmhost/contexts/instanceTracker.go
@@ -7,7 +7,7 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/storage/lrucache"
 	logger "github.com/multiversx/mx-chain-logger-go"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
+	arwen "github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/wasmer"
 )
 
@@ -66,6 +66,7 @@ func NewInstanceTracker() (*instanceTracker, error) {
 func (tracker *instanceTracker) InitState() {
 	tracker.instance = nil
 	tracker.codeHash = make([]byte, 0)
+	tracker.instances = make(map[string]wasmer.InstanceHandler)
 }
 
 // PushState pushes the active instance and codeHash on the state stacks

--- a/vmhost/contexts/output_test.go
+++ b/vmhost/contexts/output_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 	contextmock "github.com/multiversx/mx-chain-vm-v1_4-go/mock/context"
 	worldmock "github.com/multiversx/mx-chain-vm-v1_4-go/mock/world"
+	arwen "github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 	"github.com/stretchr/testify/require"
 )
 
@@ -538,7 +538,7 @@ func TestOutputContext_WriteLog(t *testing.T) {
 
 	host := &contextmock.VMHostMock{
 		RuntimeContext: &contextmock.RuntimeContextMock{
-			CallFunction: "function",
+			CallFunctionName: "function",
 		},
 	}
 	outputContext, _ := NewOutputContext(host)

--- a/vmhost/contexts/runtime.go
+++ b/vmhost/contexts/runtime.go
@@ -11,8 +11,8 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	logger "github.com/multiversx/mx-chain-logger-go"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/math"
+	arwen "github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/wasmer"
 )
 
@@ -928,31 +928,43 @@ func (context *runtimeContext) isScAddressOnTheStack(scAddress []byte) bool {
 	return false
 }
 
+// CallFunction calls the specified instance function
+func (context *runtimeContext) CallFunction(funcName string) error {
+	instance := context.iTracker.Instance()
+	if !instance.HasFunction(funcName) {
+		return arwen.ErrFuncNotFound
+	}
+
+	_, err := instance.CallFunction(funcName)
+
+	return err
+}
+
 // GetFunctionToCall returns the function to call from the wasmer instance exports.
-func (context *runtimeContext) GetFunctionToCall() (wasmer.ExportedFunctionCallback, error) {
-	exports := context.iTracker.Instance().GetExports()
+func (context *runtimeContext) GetFunctionToCall() (string, error) {
+	instance := context.iTracker.Instance()
 	logRuntime.Trace("get function to call", "function", context.callFunction)
-	if function, ok := exports[context.callFunction]; ok {
-		return function, nil
+	if instance.HasFunction(context.callFunction) {
+		return context.callFunction, nil
 	}
 
 	if context.callFunction == arwen.CallbackFunctionName {
 		// TODO rewrite this condition, until the AsyncContext is merged
 		logRuntime.Trace("get function to call", "error", arwen.ErrNilCallbackFunction)
-		return nil, arwen.ErrNilCallbackFunction
+		return "", arwen.ErrNilCallbackFunction
 	}
 
-	return nil, arwen.ErrFuncNotFound
+	return "", arwen.ErrFuncNotFound
 }
 
 // GetInitFunction returns the init function from the current wasmer instance exports.
-func (context *runtimeContext) GetInitFunction() wasmer.ExportedFunctionCallback {
-	exports := context.iTracker.Instance().GetExports()
-	if init, ok := exports[arwen.InitFunctionName]; ok {
-		return init
+func (context *runtimeContext) GetInitFunction() string {
+	instance := context.iTracker.Instance()
+	if instance.HasFunction(arwen.InitFunctionName) {
+		return arwen.InitFunctionName
 	}
 
-	return nil
+	return ""
 }
 
 // ExecuteAsyncCall locks the necessary gas and sets the async call info and a runtime breakpoint value.

--- a/vmhost/contexts/runtime_test.go
+++ b/vmhost/contexts/runtime_test.go
@@ -11,15 +11,15 @@ import (
 	"github.com/multiversx/mx-chain-core-go/hashing/blake2b"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/multiversx/mx-chain-vm-common-go/builtInFunctions"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/cryptoapi"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/vmhooks"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/vmhooksmeta"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/mock"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/config"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/crypto/factory"
 	contextmock "github.com/multiversx/mx-chain-vm-v1_4-go/mock/context"
 	worldmock "github.com/multiversx/mx-chain-vm-v1_4-go/mock/world"
+	arwen "github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/cryptoapi"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/mock"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/vmhooks"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/vmhooksmeta"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/wasmer"
 	"github.com/stretchr/testify/require"
 )
@@ -368,7 +368,7 @@ func TestRuntimeContext_Instance(t *testing.T) {
 	runtimeContext.InitStateFromContractCallInput(input)
 	f, err = runtimeContext.GetFunctionToCall()
 	require.Equal(t, arwen.ErrFuncNotFound, err)
-	require.Nil(t, f)
+	require.Equal(t, "", f)
 
 	initFunc := runtimeContext.GetInitFunction()
 	require.NotNil(t, initFunc)

--- a/vmhost/host/asyncCall.go
+++ b/vmhost/host/asyncCall.go
@@ -10,9 +10,8 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/vm"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/multiversx/mx-chain-vm-common-go/parsers"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/math"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/wasmer"
+	arwen "github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 )
 
 func (host *vmHost) handleAsyncCallBreakpoint() error {
@@ -863,7 +862,7 @@ func (host *vmHost) setupAsyncCallsGas(asyncInfo *arwen.AsyncContextInfo) error 
 	return nil
 }
 
-func (host *vmHost) getFunctionByCallType(callType vm.CallType) (wasmer.ExportedFunctionCallback, error) {
+func (host *vmHost) getFunctionByCallType(callType vm.CallType) (string, error) {
 	runtime := host.Runtime()
 
 	if callType != vm.AsynchronousCallBack {
@@ -872,7 +871,7 @@ func (host *vmHost) getFunctionByCallType(callType vm.CallType) (wasmer.Exported
 
 	asyncInfo, err := host.getCurrentAsyncInfo()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	vmInput := runtime.GetVMInput()
@@ -895,7 +894,7 @@ func (host *vmHost) getFunctionByCallType(callType vm.CallType) (wasmer.Exported
 	function, err := runtime.GetFunctionToCall()
 	if err != nil && !customCallback {
 		log.Trace("get function by call type", "error", arwen.ErrNilCallbackFunction)
-		return nil, arwen.ErrNilCallbackFunction
+		return "", arwen.ErrNilCallbackFunction
 	}
 
 	return function, nil

--- a/vmhost/host/execution.go
+++ b/vmhost/host/execution.go
@@ -12,9 +12,9 @@ import (
 	"github.com/multiversx/mx-chain-core-go/data/vm"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/multiversx/mx-chain-vm-common-go/parsers"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/contexts"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/math"
+	arwen "github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/contexts"
 )
 
 func (host *vmHost) doRunSmartContractCreate(input *vmcommon.ContractCreateInput) *vmcommon.VMOutput {
@@ -703,7 +703,7 @@ func (host *vmHost) callSCMethodIndirect() error {
 		return err
 	}
 
-	_, err = function()
+	err = host.Runtime().CallFunction(function)
 	if err != nil {
 		err = host.handleBreakpointIfAny(err)
 	}
@@ -889,11 +889,11 @@ func (host *vmHost) checkFinalGasAfterExit() error {
 func (host *vmHost) callInitFunction() error {
 	runtime := host.Runtime()
 	init := runtime.GetInitFunction()
-	if init == nil {
+	if init == "" {
 		return nil
 	}
 
-	_, err := init()
+	err := runtime.CallFunction(init)
 	if err != nil {
 		err = host.handleBreakpointIfAny(err)
 	}
@@ -935,7 +935,7 @@ func (host *vmHost) callSCMethod() error {
 		return err
 	}
 
-	_, err = function()
+	err = runtime.CallFunction(function)
 	if err != nil {
 		err = host.handleBreakpointIfAny(err)
 		log.Trace("breakpoint detected and handled", "err", err)

--- a/vmhost/host/host.go
+++ b/vmhost/host/host.go
@@ -9,12 +9,12 @@ import (
 	"github.com/multiversx/mx-chain-core-go/core/check"
 	logger "github.com/multiversx/mx-chain-logger-go"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/contexts"
-	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/vmhooksmeta"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/config"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/crypto"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/crypto/factory"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/contexts"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/vmhooksmeta"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/wasmer"
 )
 

--- a/vmhost/host/host_test.go
+++ b/vmhost/host/host_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/multiversx/mx-chain-vm-common-go/builtInFunctions"
 	"github.com/multiversx/mx-chain-vm-common-go/parsers"
+	worldmock "github.com/multiversx/mx-chain-vm-v1_4-go/mock/world"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
 	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/mock"
-	worldmock "github.com/multiversx/mx-chain-vm-v1_4-go/mock/world"
 	"github.com/stretchr/testify/require"
 )
 

--- a/vmhost/interface.go
+++ b/vmhost/interface.go
@@ -141,10 +141,11 @@ type RuntimeContext interface {
 	SetMaxInstanceCount(uint64)
 	VerifyContractCode() error
 	GetInstance() wasmer.InstanceHandler
+	CallFunction(funcName string) error
 	GetWarmInstance(codeHash []byte) (wasmer.InstanceHandler, bool)
 	GetInstanceExports() wasmer.ExportsMap
-	GetInitFunction() wasmer.ExportedFunctionCallback
-	GetFunctionToCall() (wasmer.ExportedFunctionCallback, error)
+	GetInitFunction() string
+	GetFunctionToCall() (string, error)
 	GetPointsUsed() uint64
 	SetPointsUsed(gasPoints uint64)
 	MemStore(offset int32, data []byte) error

--- a/wasmer/error.go
+++ b/wasmer/error.go
@@ -8,6 +8,9 @@ import (
 // ErrFailedInstantiation indicates that a Wasmer instance could not be created
 var ErrFailedInstantiation = errors.New("could not create wasmer instance")
 
+// ErrExportNotFound indicates that the requested name was not found among the exports
+var ErrExportNotFound = errors.New("export not found")
+
 // ErrFailedCacheImports indicates that the imports could not be cached
 var ErrFailedCacheImports = errors.New("could not cache imports")
 

--- a/wasmer/instance_helpers.go
+++ b/wasmer/instance_helpers.go
@@ -80,7 +80,10 @@ func retrieveExportedMemory(wasmExports *cWasmerExportsT) (Memory, bool, error) 
 	return memory, hasMemory, nil
 }
 
-func retrieveExportedFunctions(cInstance *cWasmerInstanceT, wasmExports *cWasmerExportsT) (ExportsMap, ExportSignaturesMap, error) {
+func retrieveExportedFunctions(
+	cInstance *cWasmerInstanceT,
+	wasmExports *cWasmerExportsT,
+) (ExportsMap, ExportSignaturesMap, error) {
 	var exports = make(ExportsMap)
 	var signatures = make(ExportSignaturesMap)
 
@@ -98,66 +101,82 @@ func retrieveExportedFunctions(cInstance *cWasmerInstanceT, wasmExports *cWasmer
 		var wasmFunction = cWasmerExportToFunc(wasmExport)
 		var exportedFunctionName = cGoStringN((*cChar)(unsafe.Pointer(wasmExportName.bytes)), (cInt)(wasmExportName.bytes_len))
 
-		wrappedWasmFunction, signature, err := createExportedFunctionWrapper(cInstance, wasmFunction, exportedFunctionName)
+		callInfo, err := createExportedFunctionCallInfo(wasmFunction, exportedFunctionName)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		exports[exportedFunctionName] = wrappedWasmFunction
+		signature := &ExportedFunctionSignature{
+			InputArity:  int(callInfo.InputArity),
+			OutputArity: int(callInfo.OutputArity),
+		}
+
+		exports[exportedFunctionName] = callInfo
 		signatures[exportedFunctionName] = signature
 	}
 
 	return exports, signatures, nil
 }
 
-func createExportedFunctionWrapper(
-	cInstance *cWasmerInstanceT,
+func createExportedFunctionCallInfo(
 	wasmFunction *cWasmerExportFuncT,
 	exportedFunctionName string,
-) (func(...interface{}) (Value, error), *ExportedFunctionSignature, error) {
+) (*ExportedFunctionCallInfo, error) {
+
 	wasmFunctionInputSignatures, wasmFunctionInputsArity, err := getExportedFunctionSignature(wasmFunction, exportedFunctionName)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	wasmFunctionOutputsArity, err := getExportedFunctionOutputArity(wasmFunction, exportedFunctionName)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	signature := &ExportedFunctionSignature{
-		InputArity:  int(wasmFunctionInputsArity),
-		OutputArity: int(wasmFunctionOutputsArity),
+	callInfo := &ExportedFunctionCallInfo{
+		FuncName:       exportedFunctionName,
+		InputArity:     wasmFunctionInputsArity,
+		InputSignature: wasmFunctionInputSignatures,
+		OutputArity:    wasmFunctionOutputsArity,
 	}
 
-	wrapper := func(arguments ...interface{}) (Value, error) {
-		err = validateGivenArguments(exportedFunctionName, arguments, wasmFunctionInputsArity)
-		if err != nil {
-			return Void(), err
-		}
+	return callInfo, nil
+}
 
-		var wasmInputs []cWasmerValueT
-		wasmInputs, err = createWasmInputsFromArguments(arguments, wasmFunctionInputsArity, wasmFunctionInputSignatures, exportedFunctionName)
-		if err != nil {
-			return Void(), err
-		}
-
-		wasmOutputs, callResult := callWasmFunction(
-			cInstance,
-			exportedFunctionName,
-			wasmFunctionInputsArity,
-			wasmFunctionOutputsArity,
-			wasmInputs,
-		)
-
-		if callResult != cWasmerOk {
-			err = fmt.Errorf("failed to call the `%s` exported function", exportedFunctionName)
-			return Void(), newWrappedError(err)
-		}
-
-		var value Value
-		value, err = convertWasmOutputToValue(wasmFunctionOutputsArity, wasmOutputs, exportedFunctionName)
-		return value, err
+func callExportedFunction(
+	cInstance *cWasmerInstanceT,
+	callInfo *ExportedFunctionCallInfo,
+	arguments ...interface{},
+) (Value, error) {
+	err := validateGivenArguments(callInfo.FuncName, arguments, callInfo.InputArity)
+	if err != nil {
+		return Void(), err
 	}
-	return wrapper, signature, nil
+
+	var wasmInputs []cWasmerValueT
+	wasmInputs, err = createWasmInputsFromArguments(
+		arguments,
+		callInfo.InputArity,
+		callInfo.InputSignature,
+		callInfo.FuncName)
+	if err != nil {
+		return Void(), err
+	}
+
+	wasmOutputs, callResult := callWasmFunction(
+		cInstance,
+		callInfo.FuncName,
+		callInfo.InputArity,
+		callInfo.OutputArity,
+		wasmInputs,
+	)
+
+	if callResult != cWasmerOk {
+		err = fmt.Errorf("failed to call the `%s` exported function", callInfo.FuncName)
+		return Void(), newWrappedError(err)
+	}
+
+	var value Value
+	value, err = convertWasmOutputToValue(callInfo.OutputArity, wasmOutputs, callInfo.FuncName)
+	return value, err
 }

--- a/wasmer/interface.go
+++ b/wasmer/interface.go
@@ -3,6 +3,8 @@ package wasmer
 // InstanceHandler defines the functionality of a Wasmer instance
 type InstanceHandler interface {
 	HasMemory() bool
+	HasFunction(funcName string) bool
+	CallFunction(funcName string) (Value, error)
 	SetContextData(data uintptr)
 	GetPointsUsed() uint64
 	SetPointsUsed(points uint64)


### PR DESCRIPTION
This PR changes how instance methods are fundamentally called.

Instead of creating and storing lambda wrappers around actual instance method calls, the new code creates `struct`s that store the required information in the `instance.Exports` map. Those structs are then used by a new proper method `instance.CallFunction()`.

Previously, instance methods were executed by directly calling the aforementioned lambdas, after passing them around.
After the changes in this PR, the VM will not concern itself anymore with the actual calls. Instead, the VM focuses on the name of the method that needs to be called, and the `instance` handles the details.