### PR TITLE
Minor correction of the internal counter

### DIFF
--- a/vmhost/contexts/instanceTracker.go
+++ b/vmhost/contexts/instanceTracker.go
@@ -64,7 +64,6 @@ func NewInstanceTracker() (*instanceTracker, error) {
 
 // InitState initializes the internal instanceTracker state
 func (tracker *instanceTracker) InitState() {
-	tracker.numRunningInstances = 0
 	tracker.instance = nil
 	tracker.codeHash = make([]byte, 0)
 	tracker.instances = make(map[string]wasmer.InstanceHandler)


### PR DESCRIPTION
This PR applies a minor correction to the internal instance counter of the `InstanceTracker`. This counter is only used in logging / debugging.