### PR TITLE
Scenario API

### DIFF
--- a/scenarioapi/exec.go
+++ b/scenarioapi/exec.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"github.com/multiversx/mx-chain-vm-common-go/parsers"
+	worldhook "github.com/multiversx/mx-chain-vm-v1_4-go/mock/world"
+	gasSchedules "github.com/multiversx/mx-chain-vm-v1_4-go/scenarioexec/gasSchedules"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/hostCore"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost/mock"
+)
+
+type Executor struct {
+	world             *worldhook.MockWorld
+	vmHost            vmhost.VMHost
+}
+
+func NewExecutor() (*Executor, error) {
+	world := worldhook.NewMockWorld()
+	gasSchedule, err := gasSchedules.LoadGasScheduleConfig(gasSchedules.GetV4())
+	if err != nil {
+		return nil, err
+	}
+	err = world.InitBuiltinFunctions(gasSchedule)
+	if err != nil {
+		return nil, err
+	}
+	esdtTransferParser, err := parsers.NewESDTTransferParser(worldhook.WorldMarshalizer)
+	if err != nil {
+		return nil, err
+	}
+	vmHost, err := hostCore.NewVMHost(world, &vmhost.VMHostParameters{
+		VMType:                   []byte{0, 0},
+		BlockGasLimit:            uint64(10000000),
+		GasSchedule:              gasSchedule,
+		BuiltInFuncContainer:     world.BuiltinFuncs.Container,
+		ProtectedKeyPrefix: 			[]byte("ELROND"),
+		ESDTTransferParser:       esdtTransferParser,
+		EpochNotifier: 						&mock.EpochNotifierStub{},
+		EnableEpochsHandler: 			&mock.EnableEpochsHandlerStub{
+			IsStorageAPICostOptimizationFlagEnabledField:         true,
+			IsMultiESDTTransferFixOnCallBackFlagEnabledField:     true,
+			IsFixOOGReturnCodeFlagEnabledField:                   true,
+			IsRemoveNonUpdatedStorageFlagEnabledField:            true,
+			IsCreateNFTThroughExecByCallerFlagEnabledField:       true,
+			IsManagedCryptoAPIsFlagEnabledField:                  true,
+			IsFailExecutionOnEveryAPIErrorFlagEnabledField:       true,
+			IsRefactorContextFlagEnabledField:                    true,
+			IsCheckCorrectTokenIDForTransferRoleFlagEnabledField: true,
+			IsDisableExecByCallerFlagEnabledField:                true,
+			IsESDTTransferRoleFlagEnabledField:                   true,
+			IsGlobalMintBurnFlagEnabledField:                     true,
+			IsTransferToMetaFlagEnabledField:                     true,
+			IsCheckFrozenCollectionFlagEnabledField:              true,
+			IsFixAsyncCallbackCheckFlagEnabledField:              true,
+			IsESDTNFTImprovementV1FlagEnabledField:               true,
+			IsSaveToSystemAccountFlagEnabledField:                true,
+			IsValueLengthCheckFlagEnabledField:                   true,
+			IsSCDeployFlagEnabledField:                           true,
+			IsRepairCallbackFlagEnabledField:                     true,
+			IsAheadOfTimeGasUsageFlagEnabledField:                true,
+			IsCheckFunctionArgumentFlagEnabledField:              true,
+			IsCheckExecuteOnReadOnlyFlagEnabledField:             true,
+		},
+		WasmerSIGSEGVPassthrough: false,
+		Hasher:                   worldhook.DefaultHasher,
+	})
+	if err != nil {
+		return nil, err
+	}
+	ae := Executor{
+		world:  world,
+		vmHost: vmHost,
+	}
+	return &ae, nil
+}

--- a/scenarioapi/handleDumpAccount.go
+++ b/scenarioapi/handleDumpAccount.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/hex"
+
+	worldmock "github.com/multiversx/mx-chain-vm-v1_4-go/mock/world"
+	oj "github.com/multiversx/mx-chain-vm-v1_4-go/scenarios/orderedjson"
+)
+
+func (ae *Executor) HandleDumpAccount(strAddress string) (oj.OJsonObject, error) {
+	address, err := hex.DecodeString(strAddress)
+	if err != nil {
+		return nil, err
+	}
+	account := ae.world.AcctMap.GetAccount(address)
+	return worldAccountToOJ(account), nil
+}
+
+func worldAccountToOJ(account *worldmock.Account) oj.OJsonObject {
+	ojAccount := oj.NewMap()
+	ojAccount.Put("address", bytesToOjHexStr(account.Address))
+	ojAccount.Put("nonce", intToOjIntStr(int(account.Nonce)))
+	ojAccount.Put("egldAmount", bigintToOjIntStr(account.Balance))
+	storageOJ := oj.NewMap()
+	for k, v := range account.Storage {
+		storageOJ.Put(hex.EncodeToString([]byte(k)), bytesToOjHexStr(v))
+	}
+	ojAccount.Put("storage", storageOJ)
+	ojAccount.Put("code", bytesToOjHexStr(account.Code))
+	ojAccount.Put("owner", bytesToOjHexStr(account.OwnerAddress))
+	return ojAccount
+}

--- a/scenarioapi/handleDumpAccounts.go
+++ b/scenarioapi/handleDumpAccounts.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	oj "github.com/multiversx/mx-chain-vm-v1_4-go/scenarios/orderedjson"
+)
+
+func (ae *Executor) HandleDumpAccounts() (oj.OJsonObject, error) {
+	ojAccounts := oj.OJsonList{}
+	for _, account := range ae.world.AcctMap {
+		ojAccounts = append(ojAccounts, worldAccountToOJ(account))
+	}
+	return &ojAccounts, nil
+}

--- a/scenarioapi/handleExecuteTx.go
+++ b/scenarioapi/handleExecuteTx.go
@@ -1,0 +1,396 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/data/vm"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+	worldmock "github.com/multiversx/mx-chain-vm-v1_4-go/mock/world"
+	oj "github.com/multiversx/mx-chain-vm-v1_4-go/scenarios/orderedjson"
+	"github.com/multiversx/mx-chain-vm-v1_4-go/vmhost"
+)
+
+type Tx struct {
+	DisplayLogs   bool
+	Type      		TxType
+	From      		[]byte
+	To        		[]byte
+	EGLDAmount 	  *big.Int
+	ESDTs         []*TxESDT
+	Code      		[]byte
+	FunctionName  string
+	FunctionArgs  [][]byte
+	GasPrice  		uint64
+	GasLimit  		uint64
+}
+
+type TxESDT struct {
+	Id 		  []byte
+	Nonce   uint64
+	Amount  *big.Int
+}
+
+type TxType int
+
+const (
+	DeploySc TxType = iota
+	CallSc
+	Transfer
+)
+
+func (ae *Executor) HandleExecuteTx(reqBody []byte) (oj.OJsonObject, error) {
+	tx, err := parseTx(reqBody)
+	if err != nil {
+		return nil, err
+	}
+	return ae.executeTx(tx)
+}
+
+func parseTx(reqBody []byte) (*Tx, error) {
+	raw, err := oj.ParseOrderedJSON(reqBody)
+	if err != nil {
+		return nil, err
+	}
+	stepMap, isMap := raw.(*oj.OJsonMap)
+	if !isMap {
+		return nil, errors.New("unmarshalled block info object is not a map")
+	}
+	tx := &Tx{
+		EGLDAmount: big.NewInt(0),
+	}
+	for _, kvp := range stepMap.OrderedKV {
+		switch kvp.Key {
+			case "displayLogs":
+				tx.DisplayLogs, err = ojBoolToBool(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid transaction displayLogs: %w", err)
+				}
+			case "type":
+				typeStr, err := ojStrToStr(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid transaction type: %w", err)
+				}
+				if typeStr == "callSc" {
+					tx.Type = CallSc
+				} else if typeStr == "deploySc" {
+					tx.Type = DeploySc
+				} else if typeStr == "transfer" {
+					tx.Type = Transfer
+				} else {
+					return nil, fmt.Errorf("invalid transaction type: %w", err)
+				}
+			case "from":
+				tx.From, err = ojHexStrToBytes(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid transaction from: %w", err)
+				}
+			case "to":
+				tx.To, err = ojHexStrToBytes(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid transaction to: %w", err)
+				}
+			case "egldAmount":
+				tx.EGLDAmount, err = ojIntStrToBigint(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid transaction egldAmount: %w", err)
+				}
+			case "esdts":
+				list, isList := kvp.Value.(*oj.OJsonList);
+				if !isList {
+					return nil, errors.New("invalid transaction esdts")
+				}
+				esdts := []*TxESDT{}
+				for _, esdtRaw := range list.AsList() {
+					esdt, err := parseTxESDT(esdtRaw)
+					if err != nil {
+						return nil, fmt.Errorf("invalid transaction esdt: %w", err)
+					}
+					esdts = append(esdts, esdt)
+				}
+				tx.ESDTs = esdts
+				if err != nil {
+					return nil, fmt.Errorf("invalid transaction esdts: %w", err)
+				}
+			case "code":
+				tx.Code, err = ojHexStrToBytes(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid transaction code: %w", err)
+				}
+			case "functionName":
+				tx.FunctionName, err = ojStrToStr(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid transaction functionName: %w", err)
+				}
+			case "functionArgs":
+				list, isList := kvp.Value.(*oj.OJsonList);
+				if !isList {
+					return nil, errors.New("invalid transaction functionArguments")
+				}
+				var arguments [][]byte
+				for _, item := range list.AsList() {
+					argument, err := ojHexStrToBytes(item)
+					if err != nil {
+						return nil, fmt.Errorf("invalid transaction functionArgument: %w", err)
+					}
+					arguments = append(arguments, argument)
+				}
+				tx.FunctionArgs = arguments
+				if err != nil {
+					return nil, fmt.Errorf("invalid transaction functionArguments: %w", err)
+				}
+			case "gasLimit":
+				tx.GasLimit, err = ojIntStrToUint64(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid transaction gasLimit: %w", err)
+				}
+			case "gasPrice":
+				tx.GasPrice, err = ojIntStrToUint64(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid transaction gasPrice: %w", err)
+				}
+			default:
+				return nil, fmt.Errorf("unknown transaction field: %s", kvp.Key)
+		}
+	}
+	return tx, nil
+}
+
+func parseTxESDT(esdtRaw oj.OJsonObject) (*TxESDT, error) {
+	esdtMap, isMap := esdtRaw.(*oj.OJsonMap)
+	if !isMap {
+		return nil, fmt.Errorf("wrong ESDT Multi-Transfer format")
+	}
+	esdtData := TxESDT{}
+	var err error
+	for _, kvp := range esdtMap.OrderedKV {
+		switch kvp.Key {
+			case "id":
+				esdtData.Id, err = ojStrToBytes(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid ESDT token name: %w", err)
+				}
+			case "nonce":
+				esdtData.Nonce, err = ojIntStrToUint64(kvp.Value)
+				if err != nil {
+					return nil, errors.New("invalid account nonce")
+				}
+			case "amount":
+				esdtData.Amount, err = ojIntStrToBigint(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid ESDT balance: %w", err)
+				}
+			default:
+				return nil, fmt.Errorf("unknown transaction ESDT data field: %s", kvp.Key)
+		}
+	}
+	return &esdtData, nil
+}
+
+
+func (ae *Executor) executeTx(tx *Tx) (oj.OJsonObject, error) {
+	if tx.DisplayLogs {
+		vmhost.SetLoggingForTests()
+	}
+	vmOutput, err := ae._executeTx(tx)
+	if tx.DisplayLogs {
+		vmhost.DisableLoggingForTests()
+	}
+	if err != nil {
+		return nil, err
+	}
+	return vmOutputToOJ(vmOutput), err
+}
+
+func (ae *Executor) _executeTx(tx *Tx) (*vmcommon.VMOutput, error) {
+	ae.world.CreateStateBackup()
+	var err error
+	defer func() {
+		if err != nil {
+			errRollback := ae.world.RollbackChanges()
+			if errRollback != nil {
+				err = errRollback
+			}
+		} else {
+			errCommit := ae.world.CommitChanges()
+			if errCommit != nil {
+				err = errCommit
+			}
+		}
+	}()
+	sender := ae.world.AcctMap.GetAccount(tx.From)
+	switch tx.Type {
+		case DeploySc:
+			newAddressMock := &worldmock.NewAddressMock{
+				CreatorAddress: sender.Address,
+				CreatorNonce:   sender.Nonce,
+				NewAddress:     tx.To,
+			}
+			ae.world.NewAddressMocks = append(ae.world.NewAddressMocks, newAddressMock)
+	}
+	err = ae.world.UpdateWorldStateBefore(tx.From, tx.GasLimit, tx.GasPrice)
+	if err != nil {
+		return nil, fmt.Errorf("could not set up tx: %w", err)
+	}
+	gasForExecution := tx.GasLimit
+	if tx.ESDTs != nil {
+		vmInputArguments := [][]byte{
+			tx.To,
+			big.NewInt(0).SetUint64(uint64(len(tx.ESDTs))).Bytes(),
+		}
+		for _, esdtTransfer := range tx.ESDTs {
+			vmInputArguments = append(
+				vmInputArguments,
+				esdtTransfer.Id,
+				big.NewInt(0).SetUint64(esdtTransfer.Nonce).Bytes(),
+				esdtTransfer.Amount.Bytes(),
+			)
+		}
+		vmCallInput := &vmcommon.ContractCallInput{
+			VMInput: vmcommon.VMInput{
+				CallerAddr:  tx.From,
+				Arguments:   vmInputArguments,
+				CallValue:   big.NewInt(0),
+				CallType:    vm.DirectCall,
+				GasPrice:    tx.GasPrice,
+				GasProvided: gasForExecution,
+				GasLocked:   0,
+			},
+			RecipientAddr:     tx.From,
+			Function:          core.BuiltInFunctionMultiESDTNFTTransfer,
+			AllowInitFunction: false,
+		}
+		vmOutput, err := ae.world.BuiltinFuncs.ProcessBuiltInFunction(vmCallInput)
+		if err != nil {
+			return nil, err
+		}
+		if vmOutput.ReturnCode != vmcommon.Ok {
+			return nil, fmt.Errorf(
+				"MultiESDTtransfer failed: retcode = %d, msg = %s",
+				vmOutput.ReturnCode, vmOutput.ReturnMessage)
+		}
+		gasForExecution = vmOutput.GasRemaining
+	}
+	// we use fake vm outputs for transactions that don't use the VM, just for convenience
+	var vmOutput *vmcommon.VMOutput
+	if sender.Balance.Cmp(tx.EGLDAmount) < 0 {
+		// out of funds is handled by the protocol, so it needs to be mocked here
+		vmOutput = &vmcommon.VMOutput{
+			ReturnData:      make([][]byte, 0),
+			ReturnCode:      vmcommon.OutOfFunds,
+			ReturnMessage:   "",
+			GasRemaining:    0,
+			GasRefund:       big.NewInt(0),
+			OutputAccounts:  make(map[string]*vmcommon.OutputAccount),
+			DeletedAccounts: make([][]byte, 0),
+			TouchedAccounts: make([][]byte, 0),
+			Logs:            make([]*vmcommon.LogEntry, 0),
+		}
+	} else {
+		switch tx.Type {
+			case DeploySc:
+				txHash := make([]byte, 0)
+				vmCallInput := &vmcommon.ContractCreateInput{
+					ContractCode: tx.Code,
+					VMInput:      vmcommon.VMInput{
+						CallerAddr:     tx.From,
+						Arguments:      tx.FunctionArgs,
+						CallValue:      tx.EGLDAmount,
+						GasPrice:       tx.GasPrice,
+						GasProvided:    gasForExecution,
+						OriginalTxHash: txHash,
+						CurrentTxHash:  txHash,
+						ESDTTransfers:  esdtTransfersToVmEsdtTransfers(tx.ESDTs),
+					},
+				}
+				vmOutput, err = ae.vmHost.RunSmartContractCreate(vmCallInput)
+				if err != nil {
+					return nil, err
+				}
+			case CallSc:
+				txHash := make([]byte, 0)
+				vmCallInput := &vmcommon.ContractCallInput{
+					RecipientAddr: tx.To,
+					Function:      tx.FunctionName,
+					VMInput:       vmcommon.VMInput{
+						CallerAddr:     tx.From,
+						Arguments:      tx.FunctionArgs,
+						CallValue:      tx.EGLDAmount,
+						GasPrice:       tx.GasPrice,
+						GasProvided:    gasForExecution,
+						OriginalTxHash: txHash,
+						CurrentTxHash:  txHash,
+						ESDTTransfers:  esdtTransfersToVmEsdtTransfers(tx.ESDTs),
+					},
+				}
+				vmOutput, err = ae.vmHost.RunSmartContractCall(vmCallInput)
+				if err != nil {
+					return nil, err
+				}
+			case Transfer:
+				outputAccounts := make(map[string]*vmcommon.OutputAccount)
+				outputAccounts[string(tx.To)] = &vmcommon.OutputAccount{
+					Address:      tx.To,
+					BalanceDelta: tx.EGLDAmount,
+				}
+				vmOutput = &vmcommon.VMOutput{
+					ReturnData:      make([][]byte, 0),
+					ReturnCode:      vmcommon.Ok,
+					ReturnMessage:   "",
+					GasRemaining:    0,
+					GasRefund:       big.NewInt(0),
+					OutputAccounts:  outputAccounts,
+					DeletedAccounts: make([][]byte, 0),
+					TouchedAccounts: make([][]byte, 0),
+					Logs:            make([]*vmcommon.LogEntry, 0),
+				}
+			default:
+				return nil, errors.New("unknown transaction type")
+		}
+	}
+	if vmOutput.ReturnCode == vmcommon.Ok {
+		err := ae.world.UpdateBalanceWithDelta(tx.From, big.NewInt(0).Neg(tx.EGLDAmount))
+		if err != nil {
+			return nil, err
+		}
+		err = ae.world.UpdateAccounts(vmOutput.OutputAccounts, vmOutput.DeletedAccounts)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err = fmt.Errorf(
+			"tx step failed: retcode=%d, msg=%s",
+			vmOutput.ReturnCode, vmOutput.ReturnMessage)
+	}
+	return vmOutput, nil
+}
+
+func esdtTransfersToVmEsdtTransfers(esdtTransfers []*TxESDT) []*vmcommon.ESDTTransfer {
+	vmESDTTransfers := make([]*vmcommon.ESDTTransfer, len(esdtTransfers))
+	for i := 0; i < len(esdtTransfers); i++ {
+		vmESDTTransfers[i] = &vmcommon.ESDTTransfer{}
+		vmESDTTransfers[i].ESDTTokenName = esdtTransfers[i].Id
+		vmESDTTransfers[i].ESDTTokenNonce = esdtTransfers[i].Nonce
+		vmESDTTransfers[i].ESDTValue = esdtTransfers[i].Amount
+		if vmESDTTransfers[i].ESDTTokenNonce != 0 {
+			vmESDTTransfers[i].ESDTTokenType = uint32(core.NonFungible)
+		} else {
+			vmESDTTransfers[i].ESDTTokenType = uint32(core.Fungible)
+		}
+	}
+	return vmESDTTransfers
+}
+
+func vmOutputToOJ(vmOutput *vmcommon.VMOutput) oj.OJsonObject {
+	ojOutput := oj.NewMap()
+	ojOutput.Put("code", intToOjIntStr(int(vmOutput.ReturnCode)))
+	ojOutput.Put("message", strToOjStr(vmOutput.ReturnMessage))
+	var returnData oj.OJsonList
+	for _, data := range vmOutput.ReturnData {
+		returnData = append(returnData, bytesToOjHexStr(data))
+	}
+	ojOutput.Put("data", &returnData)
+	return ojOutput
+}

--- a/scenarioapi/handleReset.go
+++ b/scenarioapi/handleReset.go
@@ -1,0 +1,10 @@
+package main
+
+import oj "github.com/multiversx/mx-chain-vm-v1_4-go/scenarios/orderedjson"
+
+func (ae *Executor) HandleReset() (oj.OJsonObject, error) {
+	ae.world.Clear()
+	ae.vmHost.Reset()
+	ojBool := oj.OJsonBool(true)
+	return &ojBool, nil
+}

--- a/scenarioapi/handleSetAccount.go
+++ b/scenarioapi/handleSetAccount.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+	worldmock "github.com/multiversx/mx-chain-vm-v1_4-go/mock/world"
+	oj "github.com/multiversx/mx-chain-vm-v1_4-go/scenarios/orderedjson"
+)
+
+type Account struct {
+	Address         []byte
+	Nonce           uint64
+	Balance         *big.Int
+	Storage         []*StorageKeyValuePair
+	Code            []byte
+	Owner           []byte
+}
+
+type StorageKeyValuePair struct {
+	Key   []byte
+	Value []byte
+}
+
+func (ae *Executor) HandleSetAccount(strAddress string, reqBody []byte) (oj.OJsonObject, error) {
+	address, err := hex.DecodeString(strAddress)
+	if err != nil {
+		return nil, err
+	}
+	account, err := parseAccount(address, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	ojBool := oj.OJsonBool(true)
+	err = ae.setAccount(account)
+	return &ojBool, err
+}
+
+func parseAccount(address []byte, reqBody []byte) (*Account, error) {
+	raw, err := oj.ParseOrderedJSON(reqBody)
+	if err != nil {
+		return nil, err
+	}
+	accountMap, isMap := raw.(*oj.OJsonMap)
+	if !isMap {
+		return nil, errors.New("unmarshalled account object is not a map")
+	}
+	account := &Account{
+		Address: 				 address,
+		Nonce:           0,
+		Balance:         big.NewInt(0),
+	}
+	for _, kvp := range accountMap.OrderedKV {
+		switch kvp.Key {
+			case "nonce":
+				account.Nonce, err = ojIntStrToUint64(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid account nonce: %w", err)
+				}
+			case "egldAmount":
+				account.Balance, err = ojIntStrToBigint(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid account balance: %w", err)
+				}
+			case "storage":
+				storageMap, storageOk := kvp.Value.(*oj.OJsonMap)
+				if !storageOk {
+					return nil, errors.New("invalid account storage")
+				}
+				for _, storageKvp := range storageMap.OrderedKV {
+					byteKey, err := hex.DecodeString(storageKvp.Key)
+					if err != nil {
+						return nil, fmt.Errorf("invalid account storage key: %w", err)
+					}
+					byteVal, err := ojHexStrToBytes(storageKvp.Value)
+					if err != nil {
+						return nil, fmt.Errorf("invalid account storage value: %w", err)
+					}
+					stElem := StorageKeyValuePair{
+						Key:   byteKey,
+						Value: byteVal,
+					}
+					account.Storage = append(account.Storage, &stElem)
+				}
+			case "code":
+				account.Code, err = ojHexStrToBytes(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid account code: %w", err)
+				}
+			case "owner":
+				account.Owner, err = ojHexStrToBytes(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("invalid account owner: %w", err)
+				}
+			default:
+				return nil, fmt.Errorf("unknown account field: %s", kvp.Key)
+		}
+	}
+	return account, nil
+}
+
+func (ae *Executor) setAccount(account *Account) error {
+	storage := make(map[string][]byte)
+	for _, kvp := range account.Storage {
+		storage[string(kvp.Key)] = kvp.Value
+	}
+	worldAccount := &worldmock.Account{
+		Address:         account.Address,
+		Nonce:           account.Nonce,
+		Balance:         big.NewInt(0).Set(account.Balance),
+		BalanceDelta:    big.NewInt(0),
+		DeveloperReward: big.NewInt(0),
+		Storage:         storage,
+		Code:            account.Code,
+		OwnerAddress:    account.Owner,
+		IsSmartContract: len(account.Code) > 0,
+		CodeMetadata: (&vmcommon.CodeMetadata{
+			Payable:     true,
+			Upgradeable: true,
+			Readable:    true,
+		}).ToBytes(),
+		MockWorld: ae.world,
+	}
+	err := worldAccount.Validate()
+	if err != nil {
+		return err
+	}
+	ae.world.AcctMap.PutAccount(worldAccount)
+	return nil
+}

--- a/scenarioapi/handleSetCurrentBlockInfo.go
+++ b/scenarioapi/handleSetCurrentBlockInfo.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	worldmock "github.com/multiversx/mx-chain-vm-v1_4-go/mock/world"
+	oj "github.com/multiversx/mx-chain-vm-v1_4-go/scenarios/orderedjson"
+)
+
+type BlockInfo struct {
+	Timestamp  uint64
+	Nonce      uint64
+	Round      uint64
+	Epoch      uint64
+}
+
+func (ae *Executor) HandleSetCurrentBlockInfo(reqBody []byte) (oj.OJsonObject, error) {
+	blockInfo, err := parseBlockInfo(reqBody)
+	if err != nil {
+		return nil, err
+	}
+	ae.setCurrentBlockInfo(blockInfo)
+	ojBool := oj.OJsonBool(true)
+	return &ojBool, nil
+}
+
+func parseBlockInfo(reqBody []byte) (*BlockInfo, error) {
+	raw, err := oj.ParseOrderedJSON(reqBody)
+	if err != nil {
+		return nil, err
+	}
+	blockMap, isMap := raw.(*oj.OJsonMap)
+	if !isMap {
+		return nil, errors.New("unmarshalled block info object is not a map")
+	}
+	blockInfo := &BlockInfo{}
+	for _, kvp := range blockMap.OrderedKV {
+		switch kvp.Key {
+			case "timestamp":
+				blockInfo.Timestamp, err = ojIntStrToUint64(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("error parsing blockTimestamp: %w", err)
+				}
+			case "nonce":
+				blockInfo.Nonce, err = ojIntStrToUint64(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("error parsing blockNonce: %w", err)
+				}
+			case "round":
+				blockInfo.Round, err = ojIntStrToUint64(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("error parsing blockRound: %w", err)
+				}
+			case "epoch":
+				blockInfo.Epoch, err = ojIntStrToUint64(kvp.Value)
+				if err != nil {
+					return nil, fmt.Errorf("error parsing blockEpoch: %w", err)
+				}
+			default:
+				return nil, fmt.Errorf("unknown block info field: %s", kvp.Key)
+		}
+	}
+	return blockInfo, nil
+}
+
+func (ae *Executor) setCurrentBlockInfo(blockInfo *BlockInfo) {
+	ae.world.CurrentBlockInfo = &worldmock.BlockInfo{
+		BlockTimestamp: blockInfo.Timestamp,
+		BlockNonce:     blockInfo.Nonce,
+		BlockRound:     blockInfo.Round,
+		BlockEpoch:     uint32(blockInfo.Epoch),
+		RandomSeed:     nil,
+	}
+}

--- a/scenarioapi/main.go
+++ b/scenarioapi/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	oj "github.com/multiversx/mx-chain-vm-v1_4-go/scenarios/orderedjson"
+)
+
+func main() {
+	fmt.Println("Instantiating Executor")
+	executor, err := NewExecutor()
+	if err != nil {
+		panic("Failed to instantiate Executor")
+	}
+
+	http.HandleFunc("/DumpAccounts", func(w http.ResponseWriter, r *http.Request) {
+		resBody, err := executor.HandleDumpAccounts()
+		respond(w, resBody, err)
+	})
+
+	http.HandleFunc("/DumpAccount", func(w http.ResponseWriter, r *http.Request) {
+		strAddress := r.URL.Query().Get("address")
+		resBody, err := executor.HandleDumpAccount(strAddress)
+		respond(w, resBody, err)
+	})
+
+	http.HandleFunc("/ExecuteTx", func(w http.ResponseWriter, r *http.Request) {
+		reqBody, _ := io.ReadAll(r.Body)
+		resBody, err := executor.HandleExecuteTx(reqBody)
+		respond(w, resBody, err)
+	})
+
+	http.HandleFunc("/SetAccount", func(w http.ResponseWriter, r *http.Request) {
+		strAddress := r.URL.Query().Get("address")
+		reqBody, _ := io.ReadAll(r.Body)
+		resBody, err := executor.HandleSetAccount(strAddress, reqBody)
+		respond(w, resBody, err)
+	})
+
+	http.HandleFunc("/SetCurrentBlockInfo", func(w http.ResponseWriter, r *http.Request) {
+		reqBody, _ := io.ReadAll(r.Body)
+		resBody, err := executor.HandleSetCurrentBlockInfo(reqBody)
+		respond(w, resBody, err)
+	})
+
+	http.HandleFunc("/Reset", func(w http.ResponseWriter, r *http.Request) {
+		resBody, err := executor.HandleReset()
+		respond(w, resBody, err)
+	})
+
+	fmt.Println("Starting server at port 8080")
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func respond(w http.ResponseWriter, resBody oj.OJsonObject, err error) {
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	} else {
+		fmt.Fprint(w, oj.JSONString(resBody))
+	}
+}

--- a/scenarioapi/other.go
+++ b/scenarioapi/other.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+
+	oj "github.com/multiversx/mx-chain-vm-v1_4-go/scenarios/orderedjson"
+)
+
+func bigintToStr(value *big.Int) string {
+	return fmt.Sprintf("%d", value)
+}
+
+func intToStr(value int) string {
+	return fmt.Sprintf("%d", value);
+}
+
+func strToOjStr(str string) oj.OJsonObject {
+	return &oj.OJsonString{Value: str}
+}
+
+func bigintToOjIntStr(value *big.Int) oj.OJsonObject {
+	return strToOjStr(bigintToStr(value))
+}
+
+func intToOjIntStr(value int) oj.OJsonObject {
+	return strToOjStr(intToStr(value))
+}
+
+func bytesToOjHexStr(bytes []byte) oj.OJsonObject {
+	return strToOjStr(hex.EncodeToString(bytes))
+}
+
+func ojStrToStr(obj oj.OJsonObject) (string, error) {
+	str, isStr := obj.(*oj.OJsonString)
+	if !isStr {
+		return "", errors.New("not a string value")
+	}
+	return str.Value, nil
+}
+
+func ojBoolToBool(obj oj.OJsonObject) (bool, error) {
+	value, isBool := obj.(*oj.OJsonBool)
+	if !isBool {
+		return false, errors.New("not a bool value")
+	}
+	return bool(*value), nil
+}
+
+func ojStrToBytes(obj oj.OJsonObject) ([]byte, error) {
+	str, err := ojStrToStr(obj)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(str), nil
+}
+
+func ojHexStrToBytes(obj oj.OJsonObject) ([]byte, error) {
+	strVal, err := ojStrToStr(obj)
+	if err != nil {
+		return nil, err
+	}
+	return hex.DecodeString(strVal)
+}
+
+func ojIntStrToBigint(obj oj.OJsonObject) (*big.Int, error) {
+	strVal, err := ojStrToStr(obj)
+	if err != nil {
+		return nil, err
+	}
+	n, isInt := big.NewInt(0).SetString(strVal, 10)
+	if !isInt {
+		return nil, errors.New("not a bigint")
+	}
+	return n, nil
+}
+
+func ojIntStrToUint64(obj oj.OJsonObject) (uint64, error) {
+	bi, err := ojIntStrToBigint(obj)
+	if err != nil {
+		return 0, err
+	}
+	if bi == nil || !bi.IsUint64() {
+		return 0, errors.New("value is not uint64")
+	}
+	return bi.Uint64(), nil
+}


### PR DESCRIPTION
Allows to execute scenarios using an API. The following endpoints are available:

`/DumpAccounts` which returns the state of all accounts
`/DumpAccount` which returns a specific account
`/ExecuteTx` which executes a specific transaction
`/SetAccount` which sets the state of a specific account
`/SetCurrentBlockInfo` which sets current block info
`/Reset` which resets the whole state